### PR TITLE
Adding a hot_reload parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Below is a breakdown of the `LiveDirectory` class generated when creating a new 
 * `retry` [`Object`]: File content reading retry policy.
   * `every` [`Number`]: Delay between retries in **milliseconds**.
   * `max` [`Number`]: Maximum number of retries.
+* `hot_reload` [`boolean`]: Whether to listen for files changes or not. Defaults to `true`.
 
 #### LiveDirectory Properties
 | Property  | Type     | Description                |

--- a/src/components/LiveDirectory.js
+++ b/src/components/LiveDirectory.js
@@ -20,6 +20,7 @@ class LiveDirectory extends EventEmitter {
             every: 250,
             max: 2,
         },
+        hot_reload: true,
     };
 
     /**
@@ -305,6 +306,13 @@ class LiveDirectory extends EventEmitter {
             try {
                 const files = reference.#tree.files;
                 const promises = [];
+
+                // If we don't want to watch the files, let's stop the watcher as soon as the initial list of files
+                // is fetched.
+                if (this.#options.hot_reload === false) {
+                    promises.push(this.#watcher.close());
+                }
+
                 Object.keys(files).forEach((path) => {
                     // If no buffer exists for file then it is still being read
                     const current = files[path];


### PR DESCRIPTION
This allows disabling the file watcher (for instance for production environments were we know the files will not change) There is no parameter in Chokidar allowing not to listen so this is implemented by stopping Chokidar as soon as the initial list of directories has been fetched.

Closes #4 