### PR TITLE
Switching access check from write permission to read permission

### DIFF
--- a/src/shared/operators.js
+++ b/src/shared/operators.js
@@ -60,7 +60,7 @@ function is_accessible_path(path) {
         // Destructure constants for determine read & write codes
         const CONSTANTS = FileSystem.constants;
         const IS_VALID = CONSTANTS.F_OK;
-        const HAS_PERMISSION = CONSTANTS.W_OK;
+        const HAS_PERMISSION = CONSTANTS.R_OK;
         FileSystem.access(path, IS_VALID | HAS_PERMISSION, (error) => {
             if (error) return resolve(false);
             resolve(true);


### PR DESCRIPTION
Live-directory needs to be able to read the files, but does not need to write them. So when checking for access in the `is_accessible_path` function, we should check if the files are readable, not writable.