### PR TITLE
Fix(types) : Using export = instead of default

### DIFF
--- a/src/components/LiveDirectory.js
+++ b/src/components/LiveDirectory.js
@@ -28,6 +28,7 @@ const { forward_slashes, resolve_path, is_accessible_path } = require('../shared
  */
 
 class LiveDirectory extends EventEmitter {
+    static LiveFile = LiveFile;
     #path;
     #filter;
     #watcher;

--- a/types/components/LiveDirectory.d.ts
+++ b/types/components/LiveDirectory.d.ts
@@ -22,8 +22,10 @@ interface LiveDirectoryOptions {
     };
 }
 
-export default class LiveDirectory extends EventEmitter {
+declare class LiveDirectory extends EventEmitter {
     constructor(path: string, options?: LiveDirectoryOptions);
+    
+    static LiveFile : typeof LiveFile;
 
     /**
      * Returns the live file at the provided path if it exists.
@@ -61,3 +63,5 @@ export default class LiveDirectory extends EventEmitter {
      */
     get cached(): Map<string, number>;
 }
+
+export = LiveDirectory;

--- a/types/components/LiveFile.d.ts
+++ b/types/components/LiveFile.d.ts
@@ -2,7 +2,7 @@ import { Stats, BufferEncodingOption } from 'fs';
 import { Readable, ReadableOptions } from 'stream';
 import EventEmitter from 'events';
 
-export default class LiveFile extends EventEmitter {
+declare class LiveFile extends EventEmitter {
     constructor(path: string);
 
     /**
@@ -43,3 +43,5 @@ export default class LiveFile extends EventEmitter {
      */
     get cached(): boolean;
 }
+
+export = LiveFile;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import LiveFile from "./components/LiveFile";
 import LiveDirectory from "./components/LiveDirectory";
 
-export { LiveFile, LiveDirectory };
+
+export = LiveDirectory;


### PR DESCRIPTION
I had problems getting TS to properly import LiveDirectory.

```
import { LiveDirectory } from 'live-directory';
new LiveDirectory(...)
-> TypeError: live_directory_1.LiveDirectory is not a constructor
```

After checking the types I saw that the ts exports were different to the actual js exports.

e.g.
```
ts : export { LiveFile, LiveDirectory };
-> Resulting JS
const live_directory_1 = require("live-directory");
new live_directory_1.LiveDirectory(...);

js : module.exports = LiveDirectory;

```

I am not aware of any compiler flags which would fix this behaviour.
However if there are any this is my tsconfig

```
{
  "compilerOptions": {
    "target": "ES2022",
    "module": "commonjs",
    "moduleResolution": "node",
    "outDir": "build",
    "esModuleInterop": true,
    "allowSyntheticDefaultImports": true,
    "importHelpers": true,
    "alwaysStrict": true,
    "sourceMap": true,
    "forceConsistentCasingInFileNames": true,
    "experimentalDecorators": true,
    "noFallthroughCasesInSwitch": true,
    "noImplicitReturns": false,
    "noUnusedLocals": false,
    "noUnusedParameters": false,
    "noImplicitAny": false,
    "noImplicitThis": false,
    "strictNullChecks": false,
    "declaration": true,
  },
  "include": ["src/**/*", "src/__tests__/**/*"],
  "exclude": ["node_modules", "build"]
}
```

Since I assume that this is a problem of the different export types used in .js and d.ts i changed them and made this pr.

Changes : 
1. Replaced default exports with export = Class syntax.
2. Added the LiveFile type as static member of LiveDirectory.

This allows the types to be imported and used as: 

```
import LiveDirectory from 'live-directory';

const assets = new LiveDirectory(...)
const file = new LiveDirectory.LiveFile(...);
```

I'm not actually 100% sure if using the export = syntax is the right way to go, since I haven't written types for js modules before.

Furhtermore with export=x it's not possible to export other types, even if they were just declarations. 